### PR TITLE
feat: implement laboCancelButton to allow users to cancel ongoing analyses

### DIFF
--- a/bot/buttons/buttons.ts
+++ b/bot/buttons/buttons.ts
@@ -4,6 +4,7 @@ import { handleMotusTry } from './handlers/game/handleMotusTry';
 import { handleQuizButton } from './handlers/game/handleQuizButton';
 import { handleLsmsDuty } from './handlers/rp/handleLsmsDuty';
 import { handleLsmsOnCall } from './handlers/rp/handleLsmsOnCall';
+import { laboCancelButton } from './handlers/rp/laboCancelButton';
 
 export const buttons: Record<string, (interaction: ButtonInteraction) => Promise<void>> = {
     jokeSetPublicButton: jokeSetPublicButton,
@@ -11,4 +12,5 @@ export const buttons: Record<string, (interaction: ButtonInteraction) => Promise
     handleQuizButton: handleQuizButton,
     handleLsmsDuty: handleLsmsDuty,
     handleLsmsOnCall: handleLsmsOnCall,
+    laboCancelButton: laboCancelButton,
 };

--- a/bot/buttons/handlers/rp/laboCancelButton.ts
+++ b/bot/buttons/handlers/rp/laboCancelButton.ts
@@ -1,0 +1,40 @@
+import { laboInQueryManager, type LaboInQueryEntry } from '@utils/rp/labo';
+import { lsmsEmbedGenerator, lsmsErrorEmbedGenerator, lsmsSuccessEmbedGenerator } from '@utils/rp/lsms';
+import { MessageFlags, type ButtonInteraction } from 'discord.js';
+
+export async function laboCancelButton(interaction: ButtonInteraction): Promise<void> {
+    if (!interaction.guildId || !interaction.inCachedGuild()) {
+        await interaction.reply({
+            embeds: [lsmsErrorEmbedGenerator('Cette commande ne peut être utilisée que dans un serveur Discord.')],
+            flags: [MessageFlags.Ephemeral],
+        });
+        return;
+    }
+
+    await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
+
+    const messageId = interaction.message.id;
+    const { success: cancelled, entry } = laboInQueryManager.cancelByMessageId(messageId);
+    if (cancelled && entry) {
+        const cancelEmbed = lsmsEmbedGenerator()
+            .setTitle('Analyse en cours')
+            .setDescription(`Analyse pour **${entry.name}** annulée par <@${interaction.user.id}>.`)
+            .addFields(
+                {
+                    name: "Type d'analyse",
+                    value: laboInQueryManager.getAnalyseType({ type: entry.type } as LaboInQueryEntry),
+                    inline: true,
+                },
+                { name: 'Nom de la personne', value: entry.name, inline: true },
+                { name: 'Demandé par', value: `<@${interaction.user.id}>`, inline: true }
+            );
+        await interaction.message.edit({ embeds: [cancelEmbed], components: [] });
+        await interaction.editReply({
+            embeds: [lsmsSuccessEmbedGenerator("L'analyse a été annulée avec succès.")],
+        });
+    } else {
+        await interaction.editReply({
+            embeds: [lsmsErrorEmbedGenerator('Aucune analyse en cours trouvée pour ce message.')],
+        });
+    }
+}

--- a/bot/commands/handlers/rp/labo.ts
+++ b/bot/commands/handlers/rp/labo.ts
@@ -3,6 +3,9 @@ import { config } from '@utils/core/config';
 import { addLaboInQuery, laboInQueryManager, type LaboInQueryEntry } from '@utils/rp/labo';
 import { lsmsEmbedGenerator, lsmsErrorEmbedGenerator, lsmsSuccessEmbedGenerator } from '@utils/rp/lsms';
 import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
     ChatInputCommandInteraction,
     InteractionContextType,
     MessageFlags,
@@ -178,9 +181,6 @@ export const labo: ICommand = {
         const name = interaction.options.getString('nom_prenom', true);
         let result = interaction.options.getString('resultat', false) || undefined;
         const timeStr = interaction.options.getString('time', false) || undefined;
-        console.log(
-            `Labo: ${interaction.user.tag} requested a ${subcommand} analysis for ${name} with result ${result || 'random'} and time ${timeStr || 'default'}.`
-        );
         let time: number;
         if (timeStr) {
             time = parseInt(timeStr, 10);
@@ -262,8 +262,20 @@ export const labo: ICommand = {
                 },
                 { name: 'Nom de la personne', value: name, inline: true },
                 { name: 'Demandé par', value: `<@${interaction.user.id}>`, inline: true }
-            );
-        const message = await (interaction.channel as TextChannel)?.send({ embeds: [waitingEmbed] });
+            )
+            .setFooter({
+                text: 'Eve - ⚠️ Ne jamais supprimer ce message !',
+                iconURL: interaction.client.user?.displayAvatarURL() || '',
+            });
+        const cancelButton = new ButtonBuilder()
+            .setCustomId('laboCancelButton')
+            .setLabel("Annuler l'analyse")
+            .setStyle(ButtonStyle.Danger);
+        const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(cancelButton);
+        const message = await (interaction.channel as TextChannel)?.send({
+            embeds: [waitingEmbed],
+            components: [actionRow],
+        });
         if (!message) {
             await interaction.editReply({
                 embeds: [lsmsErrorEmbedGenerator("Impossible d'envoyer le message dans ce canal.")],

--- a/utils/rp/labo.ts
+++ b/utils/rp/labo.ts
@@ -69,12 +69,16 @@ class LaboInQueryManager {
             const replyMessage = await message.reply({
                 content: `<@${entry.userId}>, votre analyse est terminée. (Message supprimé automatiquement dans 1 minute)`,
             });
+
+            logger.info(`Utilisateur <@${entry.userId}> notifié de la fin de l'analyse pour ${entry.name}.`);
+
             setTimeout(() => {
                 replyMessage.delete().catch(() => null);
             }, 60000);
+        } else {
+            logger.warn(`Message introuvable pour notifier l'utilisateur <@${entry.userId}>.`);
         }
 
-        logger.info(`Utilisateur <@${entry.userId}> notifié de la fin de l'analyse pour ${entry.name}.`);
     }
 
     getAll(): LaboInQueryEntry[] {
@@ -94,6 +98,16 @@ class LaboInQueryManager {
             default:
                 return 'Analyse Inconnue';
         }
+    }
+
+    cancelByMessageId(messageId: string): { success: boolean; entry?: LaboInQueryEntry } {
+        const index = this.entries.findIndex((e) => e.messageId === messageId);
+        if (index !== -1) {
+            const saveEntry = this.entries[index];
+            this.entries.splice(index, 1);
+            return { success: true, entry: saveEntry };
+        }
+        return { success: false };
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature allowing users to cancel ongoing laboratory analyses directly from Discord messages, along with some minor improvements to logging and user feedback. The main changes include a new cancel button in the analysis workflow, the backend logic to handle cancellation, and enhancements to notification and error handling.

**Feature: Laboratory Analysis Cancellation**

* Added a cancel button to the laboratory analysis request message, allowing users to cancel an ongoing analysis via Discord. The button is styled as dangerous and labeled "Annuler l'analyse". (`bot/commands/handlers/rp/labo.ts`)
* Implemented the `laboCancelButton` handler, which processes button interactions to cancel the analysis, updates the message embed to reflect cancellation, and provides user feedback through ephemeral replies. (`bot/buttons/handlers/rp/laboCancelButton.ts`, `bot/buttons/buttons.ts`) [[1]](diffhunk://#diff-31e77df73bf3f561bd9c9aef3c1bbb091329f8a5f8cf0c74c7e17a2d61c3da8aR1-R40) [[2]](diffhunk://#diff-f66fd6709c369cd3c55b2f233cff5186e1b0326662fb239dc3ca847bb386b4dcR7-R15)
* Added the `cancelByMessageId` method to `LaboInQueryManager`, enabling analysis cancellation by Discord message ID and returning the cancelled entry for further processing. (`utils/rp/labo.ts`)

**Improvements to Logging and Feedback**

* Improved logging in `LaboInQueryManager` to better track user notifications and warn if the notification message cannot be found. (`utils/rp/labo.ts`)
* Enhanced the laboratory analysis request embed with a footer warning users not to delete the message, helping preserve workflow integrity. (`bot/commands/handlers/rp/labo.ts`)

These changes collectively improve the user experience and maintainability of the laboratory analysis workflow in Discord.